### PR TITLE
Fix: Localhost forced as callback hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a Firebot Script that will allow you to integrate Spotify functionality 
   - App name and description can be whatever you want
   - Website is optional, also doesn't matter what you use here
   - Callback Url must be `http://localhost:7472/api/v1/auth/callback`
+    - Change `localhost` to your specified Callback Hostname if you changed that in the script settings
   - API/SDKs to use are Web API and Web Playback API
   - Click checkbox to agree with Spotify's TOS and Design Guidelines
 - Take note of the Client ID and Client Secret, these are required to use this script

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "oceanity-spotify",
-  "version": "0.7.4b",
+  "version": "0.7.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oceanity-spotify",
-      "version": "0.7.4b",
+      "version": "0.7.6",
       "license": "GNU3",
       "devDependencies": {
-        "@crowbartools/firebot-custom-scripts-types": "^5.60.1",
+        "@crowbartools/firebot-custom-scripts-types": "^5.63.2",
         "@oceanity/firebot-helpers": "^1.1.1",
         "@types/express": "^4.17.21",
         "@types/fs-extra": "^11.0.4",
@@ -690,10 +690,11 @@
       "dev": true
     },
     "node_modules/@crowbartools/firebot-custom-scripts-types": {
-      "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@crowbartools/firebot-custom-scripts-types/-/firebot-custom-scripts-types-5.60.1.tgz",
-      "integrity": "sha512-v0dTfKuZ2iyaMjiGFnB4pJP8xyeTLDnIfC6utAfwoxQbKeRXWZkZ/J0N73V3lWPkZl/McS77lkVEtlSH+g7k5A==",
+      "version": "5.63.2",
+      "resolved": "https://registry.npmjs.org/@crowbartools/firebot-custom-scripts-types/-/firebot-custom-scripts-types-5.63.2.tgz",
+      "integrity": "sha512-1W+8W+eesFVp6ZrqEUfNgZXHNoJkbqSqLl5fvXVbwFCFxRHL23X/I25RWlou/Y7ZoHMill/NZMal8ajKVgGW3A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@twurple/api": "^7.0.6",
         "@twurple/auth": "^7.0.6",
@@ -8863,9 +8864,9 @@
       "dev": true
     },
     "@crowbartools/firebot-custom-scripts-types": {
-      "version": "5.60.1",
-      "resolved": "https://registry.npmjs.org/@crowbartools/firebot-custom-scripts-types/-/firebot-custom-scripts-types-5.60.1.tgz",
-      "integrity": "sha512-v0dTfKuZ2iyaMjiGFnB4pJP8xyeTLDnIfC6utAfwoxQbKeRXWZkZ/J0N73V3lWPkZl/McS77lkVEtlSH+g7k5A==",
+      "version": "5.63.2",
+      "resolved": "https://registry.npmjs.org/@crowbartools/firebot-custom-scripts-types/-/firebot-custom-scripts-types-5.63.2.tgz",
+      "integrity": "sha512-1W+8W+eesFVp6ZrqEUfNgZXHNoJkbqSqLl5fvXVbwFCFxRHL23X/I25RWlou/Y7ZoHMill/NZMal8ajKVgGW3A==",
       "dev": true,
       "requires": {
         "@twurple/api": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Oceanity",
   "license": "GNU3",
   "devDependencies": {
-    "@crowbartools/firebot-custom-scripts-types": "^5.60.1",
+    "@crowbartools/firebot-custom-scripts-types": "^5.63.2",
     "@oceanity/firebot-helpers": "^1.1.1",
     "@types/express": "^4.17.21",
     "@types/fs-extra": "^11.0.4",

--- a/src/firebot/effects/spotifyCancelUserQueuesEffect.ts
+++ b/src/firebot/effects/spotifyCancelUserQueuesEffect.ts
@@ -1,7 +1,7 @@
 import { spotify } from "@/main";
 import { Firebot } from "@crowbartools/firebot-custom-scripts-types";
-import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 import { logger } from "@oceanity/firebot-helpers/firebot";
+import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 
 type EffectParams = { username: string; amount: string };
 
@@ -13,7 +13,6 @@ export const SpotifyCancelUserQueuesEffect: Firebot.EffectType<EffectParams> = {
       "Skips the last or all queues made by provided user (or all tracks if no user is provided)",
     icon: "fab fa-spotify",
     categories: ["integrations"],
-    //@ts-expect-error ts2353
     outputs: [
       {
         label: "Track(s) were skipped",

--- a/src/firebot/effects/spotifyChangePlaybackStateEffect.ts
+++ b/src/firebot/effects/spotifyChangePlaybackStateEffect.ts
@@ -12,7 +12,6 @@ export const SpotifyChangePlaybackStateEffect: Firebot.EffectType<EffectParams> 
       description: "Changes playback state of active Spotify device",
       icon: "fab fa-spotify",
       categories: ["integrations"],
-      //@ts-expect-error ts2353
       outputs: [
         {
           label: "Playback state was changed",

--- a/src/firebot/effects/spotifyChangePlaybackVolumeEffect.ts
+++ b/src/firebot/effects/spotifyChangePlaybackVolumeEffect.ts
@@ -1,6 +1,6 @@
 import { spotify } from "@/main";
-import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 import { Firebot } from "@crowbartools/firebot-custom-scripts-types";
+import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 
 type EffectParams = { volume: string };
 
@@ -12,7 +12,6 @@ export const SpotifyChangePlaybackVolumeEffect: Firebot.EffectType<EffectParams>
       description: "Changes playback volume of active Spotify device",
       icon: "fab fa-spotify",
       categories: ["integrations"],
-      //@ts-expect-error ts2353
       outputs: [
         {
           label: "Volume was changed",

--- a/src/firebot/effects/spotifyChangeRepeatStateEffect.ts
+++ b/src/firebot/effects/spotifyChangeRepeatStateEffect.ts
@@ -14,7 +14,6 @@ export const SpotifyChangeRepeatStateEffect: Firebot.EffectType<EffectParams> =
       description: "Changes repeat mode of active Spotify device",
       icon: "fab fa-spotify",
       categories: ["integrations"],
-      //@ts-expect-error ts2353
       outputs: [
         {
           label: "Repeat mode was changed",

--- a/src/firebot/effects/spotifyFindAndEnqueueTrackEffect.ts
+++ b/src/firebot/effects/spotifyFindAndEnqueueTrackEffect.ts
@@ -1,8 +1,8 @@
 import { spotify } from "@/main";
-import { logger } from "@oceanity/firebot-helpers/firebot";
 import { trackSummaryFromDetails } from "@/utils/spotify/player/track";
-import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 import { Firebot } from "@crowbartools/firebot-custom-scripts-types";
+import { logger } from "@oceanity/firebot-helpers/firebot";
+import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 
 type EffectParams = {
   query: string;
@@ -20,7 +20,6 @@ export const SpotifyFindAndEnqueueTrackEffect: Firebot.EffectType<EffectParams> 
       description: "Searches for a track to add to your Spotify queue",
       icon: "fab fa-spotify",
       categories: ["integrations"],
-      //@ts-expect-error ts2353
       outputs: [
         {
           label: "Track was enqueued",

--- a/src/firebot/effects/spotifySeekToPositionEffect.ts
+++ b/src/firebot/effects/spotifySeekToPositionEffect.ts
@@ -1,6 +1,6 @@
 import { spotify } from "@/main";
-import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 import { Firebot } from "@crowbartools/firebot-custom-scripts-types";
+import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 
 type EffectParams = { seekPosition: number };
 
@@ -11,7 +11,6 @@ export const SpotifySeekToPositionEffect: Firebot.EffectType<EffectParams> = {
     description: "Seeks to position in track",
     icon: "fab fa-spotify",
     categories: ["integrations"],
-    //@ts-expect-error ts2353
     outputs: [
       {
         label: "Seek was successful",

--- a/src/firebot/effects/spotifySkipTrackEffect.ts
+++ b/src/firebot/effects/spotifySkipTrackEffect.ts
@@ -1,6 +1,6 @@
 import { spotify } from "@/main";
-import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 import { Firebot } from "@crowbartools/firebot-custom-scripts-types";
+import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 
 export enum SpotifySkipTarget {
   Previous = "Previous",
@@ -16,7 +16,6 @@ export const SpotifySkipTrackEffect: Firebot.EffectType<EffectParams> = {
     description: "Skip current track on active Spotify device",
     icon: "fab fa-spotify",
     categories: ["integrations"],
-    //@ts-expect-error ts2353
     outputs: [
       {
         label: "Track was skipped",

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,12 @@ import { SpotifyService } from "./utils/spotify/index";
 
 export let spotify: SpotifyService;
 
+type Params = {
+  spotifyClientId: string;
+  spotifyClientSecret: string;
+  spotifyCallbackHostname: string;
+};
+
 const script: Firebot.CustomScript<Params> = {
   getScriptManifest: () => {
     return {
@@ -35,8 +41,7 @@ const script: Firebot.CustomScript<Params> = {
         type: "string",
         title: "Spotify Client Id",
         default: "",
-        description: "Spotify Client Id",
-        secondaryDescription:
+        description:
           "Client Id from an application registered at developer.spotify.com",
       },
 
@@ -44,22 +49,34 @@ const script: Firebot.CustomScript<Params> = {
         type: "string",
         title: "Spotify Client Secret",
         default: "",
-        description: "Spotify Client Secret",
-        secondaryDescription:
+        description:
           "Client Secret from an application registered at developer.spotify.com",
+      },
+
+      spotifyCallbackHostname: {
+        type: "string",
+        title: "Spotify Callback Hostname",
+        default: "localhost",
+        description:
+          "Callback Hostname for the Spotify API. If for some reason Spotify doesn't let you use `localhost`, try `127.0.0.1` instead.",
       },
     };
   },
   run: async (runRequest) => {
-    const { spotifyClientId, spotifyClientSecret } = runRequest.parameters;
+    const { spotifyClientId, spotifyClientSecret, spotifyCallbackHostname } =
+      runRequest.parameters;
     const { integrationManager, logger } = runRequest.modules;
 
-    if (!spotifyClientId || !spotifyClientSecret) {
-      logger.error(
-        "Missing required Spotify Client ID or Client Secret",
-        spotifyClientId,
-        spotifyClientSecret
+    const paramErrors = Object.entries(runRequest.parameters)
+      .filter(([_, value]) => !!value)
+      .map(([key]) =>
+        key
+          .replace(/([a-z])([A-Z])/g, "$1 $2")
+          .replace(/^\w/, (c) => c.toUpperCase())
       );
+
+    if (paramErrors.length) {
+      logger.error(`Missing required parameters: ${paramErrors.join(", ")}`);
       return;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,21 @@
-import { Firebot } from "@crowbartools/firebot-custom-scripts-types";
 import {
-  generateSpotifyIntegration,
   generateSpotifyDefinition,
+  generateSpotifyIntegration,
 } from "@/spotifyIntegration";
+import { Firebot } from "@crowbartools/firebot-custom-scripts-types";
 import * as packageJson from "../package.json";
 
-export const { version, name: namespace, displayName: name, description, author } = packageJson;
+export const {
+  version,
+  name: namespace,
+  displayName: name,
+  description,
+  author,
+} = packageJson;
 
-import { initModules } from "@oceanity/firebot-helpers/firebot";
-import { chatFeedAlert } from "@oceanity/firebot-helpers/firebot";
-import { SpotifyService } from "./utils/spotify/index";
+import { chatFeedAlert, initModules } from "@oceanity/firebot-helpers/firebot";
 import { checkRemoteVersionAsync } from "./firebot/webhooks/versionCheck";
+import { SpotifyService } from "./utils/spotify/index";
 
 export let spotify: SpotifyService;
 
@@ -28,6 +33,7 @@ const script: Firebot.CustomScript<Params> = {
     return {
       spotifyClientId: {
         type: "string",
+        title: "Spotify Client Id",
         default: "",
         description: "Spotify Client Id",
         secondaryDescription:
@@ -36,6 +42,7 @@ const script: Firebot.CustomScript<Params> = {
 
       spotifyClientSecret: {
         type: "string",
+        title: "Spotify Client Secret",
         default: "",
         description: "Spotify Client Secret",
         secondaryDescription:

--- a/src/spotifyIntegration.ts
+++ b/src/spotifyIntegration.ts
@@ -1,20 +1,20 @@
-import { EventEmitter } from "events";
+import { namespace } from "@/main";
+import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
 import ResponseError from "@models/responseError";
 import {
-  logger,
-  integrationManager,
   effectManager,
-  variableManager,
   eventManager,
   httpServer,
+  integrationManager,
+  logger,
+  variableManager,
 } from "@oceanity/firebot-helpers/firebot";
-import { namespace } from "@/main";
+import { now } from "@utils/time";
+import { EventEmitter } from "events";
 import { AllSpotifyEffects } from "./firebot/effects";
+import { SpotifyEventSource } from "./firebot/events/spotifyEventSource";
 import { AllSpotifyReplaceVariables } from "./firebot/variables";
 import { AllSpotifyWebhooks } from "./firebot/webhooks";
-import { SpotifyEventSource } from "./firebot/events/spotifyEventSource";
-import { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
-import { now } from "@utils/time";
 
 const spotifyScopes = [
   "app-remote-control",
@@ -144,7 +144,8 @@ export class SpotifyIntegration extends EventEmitter {
 }
 
 export const generateSpotifyDefinition = (
-  client: ClientCredentials
+  client: ClientCredentials,
+  redirectUriHost: string = "localhost"
 ): IntegrationDefinition => ({
   id: namespace,
   name: "Spotify (by Oceanity)",
@@ -156,7 +157,7 @@ export const generateSpotifyDefinition = (
   authProviderDetails: {
     id: namespace,
     name: "Spotify",
-    redirectUriHost: "localhost",
+    redirectUriHost,
     client,
     auth: {
       type: "code",

--- a/src/types/script.d.ts
+++ b/src/types/script.d.ts
@@ -12,11 +12,6 @@ type ClientCredentials = {
   secret: string;
 };
 
-interface Params {
-  spotifyClientId: string;
-  spotifyClientSecret: string;
-}
-
 type IntegrationDefinition<Params extends FirebotParams = FirebotParams> = {
   id: string;
   name: string;


### PR DESCRIPTION
- Allow users to overwrite callback hostname with a custom one in case Spotify blocks `localhost` as being an acceptable one
- Some minor housekeeping