### PR TITLE
Lower search limit to 10

### DIFF
--- a/scripts/copy-build.ts
+++ b/scripts/copy-build.ts
@@ -21,7 +21,7 @@ const getFirebotScriptsFolderPath = () => {
   if (process.platform === "win32") {
     appDataFolderPath = process.env.APPDATA;
   } else if (process.platform === "darwin") {
-    appDataFolderPath = path.resolve(home, "/Library/Application Support");
+    appDataFolderPath = path.resolve(home, "Library/Application Support");
   } else if (process.platform === "linux") {
     appDataFolderPath = path.resolve(home, "/.config");
   }

--- a/src/utils/spotify/index.ts
+++ b/src/utils/spotify/index.ts
@@ -57,7 +57,7 @@ export class SpotifyService {
       const params = new URLSearchParams({
         q: encodedQuery,
         type: types.join(","),
-        limit: String(options.limit ?? 50),
+        limit: String(options.limit ?? 10),
         offset: String(options.offset ?? 0),
       }).toString();
 


### PR DESCRIPTION
It seems that Spotify has lowered the maximum allowed value for the `limit` parameter in the `/search` endpoint down to 10: https://developer.spotify.com/documentation/web-api/reference/search

This was causing the enqueue effect not to be working.

Edit: also fixed copy-build for macOS which wasn't working either.