### PR TITLE
Fix double URL-encoding of Spotify search queries

### DIFF
--- a/src/utils/spotify/index.ts
+++ b/src/utils/spotify/index.ts
@@ -52,10 +52,8 @@ export class SpotifyService {
         types = [types];
       }
 
-      const encodedQuery = encodeURIComponent(query);
-
       const params = new URLSearchParams({
-        q: encodedQuery,
+        q: query,
         type: types.join(","),
         limit: String(options.limit ?? 50),
         offset: String(options.offset ?? 0),


### PR DESCRIPTION
## Summary
- `searchAsync` was encoding the query twice — once manually via `encodeURIComponent`, once again via \`URLSearchParams\`'s own encoding — corrupting any query with non-ASCII or special characters before it reached Spotify's Search API.
- Removes the redundant manual encoding; `URLSearchParams` already encodes its values correctly on its own.

Fixes #104

## Test plan
- [x] `npm test` — all existing suites pass
- [x] `npm run build` — compiles clean
- [x] Manually verified in Firebot: searching a Cyrillic query that previously returned unrelated results now returns the correct match