### PR TITLE
Stop retry storm on playlists Spotify no longer serves

### DIFF
--- a/src/models/rateLimitedError.ts
+++ b/src/models/rateLimitedError.ts
@@ -1,0 +1,12 @@
+export default class RateLimitedError extends Error {
+  retryAfterMs: number;
+
+  constructor(message: string, retryAfterMs: number) {
+    super(message);
+    this.name = this.constructor.name; // Set the error name to the class name
+    this.retryAfterMs = retryAfterMs;
+
+    // Set the prototype explicitly, because extending built-ins like Error in TypeScript requires it
+    Object.setPrototypeOf(this, RateLimitedError.prototype);
+  }
+}

--- a/src/utils/spotify/api.test.ts
+++ b/src/utils/spotify/api.test.ts
@@ -3,6 +3,7 @@ import { SpotifyService } from "@utils/spotify";
 import { SpotifyApiService } from "@utils/spotify/api";
 import { jest } from "@jest/globals";
 import { logger } from "@oceanity/firebot-helpers/firebot";
+import RateLimitedError from "@/models/rateLimitedError";
 
 type DummyDataType = {
   foo: string;
@@ -72,5 +73,118 @@ describe("Spotify - Api Service", () => {
         expect.any(Error)
       );
     }
+  });
+
+  describe("rate limiting", () => {
+    // Returns a 429 carrying the given Retry-After header, omitted when undefined
+    const rateLimited = (retryAfter?: string) =>
+      jest.fn(() => ({
+        ok: false,
+        status: 429,
+        headers: {
+          get: (name: string) =>
+            name === "retry-after" ? retryAfter ?? null : null,
+        },
+      }));
+
+    it("throws a RateLimitedError and opens a backoff window on 429", async () => {
+      // @ts-expect-error ts2322
+      global.fetch = rateLimited("5");
+
+      await expect(api.fetch("/playlists/abc")).rejects.toBeInstanceOf(
+        RateLimitedError
+      );
+
+      expect(api.backoffRemainingMs).toBeGreaterThan(0);
+      // 5s from the header, plus a second of padding
+      expect(api.backoffRemainingMs).toBeLessThanOrEqual(6000);
+    });
+
+    it("suppresses further requests without hitting the network", async () => {
+      const fetchMock = rateLimited("5");
+      // @ts-expect-error ts2322
+      global.fetch = fetchMock;
+
+      await expect(api.fetch("/playlists/abc")).rejects.toThrow();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // The poll loop would keep calling, none of these may reach Spotify
+      for (let i = 0; i < 5; i++) {
+        await expect(api.fetch("/playlists/abc")).rejects.toBeInstanceOf(
+          RateLimitedError
+        );
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("backs off every endpoint, not just the one that was limited", async () => {
+      const fetchMock = rateLimited("5");
+      // @ts-expect-error ts2322
+      global.fetch = fetchMock;
+
+      await expect(api.fetch("/playlists/abc")).rejects.toThrow();
+
+      // Spotify rate limits per app, so an unrelated endpoint has to wait too
+      await expect(api.fetch("/me/player")).rejects.toBeInstanceOf(
+        RateLimitedError
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports the remaining wait on the error", async () => {
+      // @ts-expect-error ts2322
+      global.fetch = rateLimited("5");
+
+      await expect(api.fetch("/playlists/abc")).rejects.toMatchObject({
+        retryAfterMs: 6000,
+      });
+    });
+
+    it("waits Spotify's rate limit window, not an hour, with no Retry-After", async () => {
+      // @ts-expect-error ts2322
+      global.fetch = rateLimited();
+
+      await expect(api.fetch("/playlists/abc")).rejects.toThrow();
+
+      expect(api.backoffRemainingMs).toBeGreaterThan(29000);
+      expect(api.backoffRemainingMs).toBeLessThanOrEqual(30000);
+    });
+
+    it("caps an unreasonable Retry-After", async () => {
+      // @ts-expect-error ts2322
+      global.fetch = rateLimited("100000");
+
+      await expect(api.fetch("/playlists/abc")).rejects.toThrow();
+
+      expect(api.backoffRemainingMs).toBeLessThanOrEqual(300000);
+      expect(api.backoffRemainingMs).toBeGreaterThan(299000);
+    });
+
+    it("warns once per backoff window rather than once per suppressed call", async () => {
+      // @ts-expect-error ts2322
+      global.fetch = rateLimited("5");
+
+      await expect(api.fetch("/playlists/abc")).rejects.toThrow();
+
+      for (let i = 0; i < 10; i++) {
+        await expect(api.fetch("/playlists/abc")).rejects.toThrow();
+      }
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not log rate limiting as an error", async () => {
+      // @ts-expect-error ts2322
+      global.fetch = rateLimited("5");
+
+      await expect(api.fetch("/playlists/abc")).rejects.toThrow();
+      await expect(api.fetch("/playlists/abc")).rejects.toThrow();
+
+      // Rate limiting is expected traffic shaping, it belongs at warn
+      const errors = (logger.error as jest.Mock).mock.calls;
+      expect(
+        errors.filter(([message]) => String(message).includes("Rate Limit"))
+      ).toHaveLength(0);
+    });
   });
 });

--- a/src/utils/spotify/api.ts
+++ b/src/utils/spotify/api.ts
@@ -1,15 +1,13 @@
 import { logger } from "@oceanity/firebot-helpers/firebot";
 import { SpotifyService } from ".";
 import ResponseError from "@/models/responseError";
+import RateLimitedError from "@/models/rateLimitedError";
 import {
   formatMsToTimecode,
   getErrorMessage,
 } from "@oceanity/firebot-helpers/string";
 import { mergeObjects } from "@oceanity/firebot-helpers/object";
-
-type SpotifyRateLimits = {
-  [endpoint: string]: number;
-};
+import { now } from "@utils/time";
 
 type SpotifyFetchResponse<T> = {
   status: number;
@@ -21,7 +19,16 @@ type SpotifyHttpRequestMethod = "GET" | "POST" | "PUT" | "DELETE";
 
 export class SpotifyApiService {
   private readonly spotify: SpotifyService;
-  private rateLimits: SpotifyRateLimits = {};
+
+  /**
+   * Spotify rate limits per app rather than per endpoint, so a 429 on any
+   * endpoint has to quiet all of them.
+   */
+  private _backoffUntil: number = 0;
+
+  // Spotify's rate limit window is rolling and roughly 30s
+  private static readonly defaultRetryAfterSeconds = 30;
+  private static readonly maxRetryAfterSeconds = 300;
 
   constructor(spotifyService: SpotifyService) {
     this.spotify = spotifyService;
@@ -31,11 +38,20 @@ export class SpotifyApiService {
   public getUrlFromPath = (path: string): string => `${this.baseUrl}${path}`;
 
   /**
+   * Time remaining until the API may be used again, in milliseconds.
+   * `0` when not currently rate limited.
+   */
+  public get backoffRemainingMs(): number {
+    return Math.max(0, this._backoffUntil - now());
+  }
+
+  /**
    * Makes a request to the Spotify API.
    * @param endpoint The API endpoint to request.
    * @param method The HTTP method to use. Defaults to GET.
    * @param options Additional fetch options.
    * @returns An object containing the response status, ok status, and data.
+   * @throws {RateLimitedError} If the app is currently rate limited by Spotify.
    * @throws {ResponseError} If the response status is not OK.
    * @throws {Error} If there is an error with the request.
    */
@@ -45,17 +61,16 @@ export class SpotifyApiService {
     options?: any
   ): Promise<SpotifyFetchResponse<T>> {
     try {
-      const sanitizedEndpoint = endpoint.split("?")[0];
-      const now = performance.now();
+      const backoffRemainingMs = this.backoffRemainingMs;
 
-      if (
-        this.rateLimits.hasOwnProperty(sanitizedEndpoint) &&
-        now < this.rateLimits[sanitizedEndpoint]
-      ) {
-        throw new Error(
-          `API endpoint ${endpoint} Rate Limit Exceeded, will be able to use again after ${formatMsToTimecode(
-            this.rateLimits[sanitizedEndpoint] - now
-          )}`
+      if (backoffRemainingMs > 0) {
+        // Deliberately silent. Opening the window already warned once, and
+        // callers poll through it many times over
+        throw new RateLimitedError(
+          `Spotify API endpoint ${endpoint} is rate limited, will be able to be used again in ${formatMsToTimecode(
+            backoffRemainingMs
+          )}`,
+          backoffRemainingMs
         );
       }
 
@@ -81,17 +96,25 @@ export class SpotifyApiService {
               `Spotify API endpoint ${endpoint} responded Unauthorized, try unlinking and relinking Spotify to generate a new Access/Refresh token pair`,
               response
             );
-          case 429:
-            const retryAfter = response.headers.get("retry-after");
-            this.rateLimits[sanitizedEndpoint] =
-              performance.now() +
-              (retryAfter ? parseInt(retryAfter) : 3600) * 1000;
-            throw new ResponseError(
-              `Spotify API endpoint ${endpoint} responded Rate Limit Exceeded, will be able to use again after ${new Date(
-                this.rateLimits[sanitizedEndpoint]
-              ).toUTCString()}`,
-              response
+          case 429: {
+            const retryAfterMs = this.startBackoff(
+              response.headers.get("retry-after")
             );
+
+            // The one warning for the window we just opened
+            logger.warn(
+              `Spotify API endpoint ${endpoint} responded Rate Limit Exceeded, backing off all requests for ${formatMsToTimecode(
+                retryAfterMs
+              )}`
+            );
+
+            throw new RateLimitedError(
+              `Spotify API endpoint ${endpoint} responded Rate Limit Exceeded, will be able to be used again in ${formatMsToTimecode(
+                retryAfterMs
+              )}`,
+              retryAfterMs
+            );
+          }
           default:
             throw new ResponseError(
               `Spotify API ${endpoint} returned status ${response.status}`,
@@ -116,9 +139,39 @@ export class SpotifyApiService {
         data,
       };
     } catch (error) {
+      // Rate limiting is already reported once per window, don't repeat it per call
+      if (error instanceof RateLimitedError) throw error;
+
       const message = getErrorMessage(error);
       logger.error(message, error);
       throw error;
     }
+  }
+
+  /**
+   * Opens a backoff window for every endpoint based on Spotify's `Retry-After`
+   * header, falling back to the length of Spotify's rate limit window and
+   * capping it so an unexpected header can't take the integration offline.
+   *
+   * @param retryAfterHeader The value of the `Retry-After` response header.
+   * @returns The length of the backoff window in milliseconds.
+   */
+  private startBackoff(retryAfterHeader: string | null): number {
+    const parsed = retryAfterHeader ? parseInt(retryAfterHeader, 10) : NaN;
+
+    // Add a second of padding so we don't come back a hair too early
+    const requestedSeconds = Number.isFinite(parsed)
+      ? parsed + 1
+      : SpotifyApiService.defaultRetryAfterSeconds;
+
+    const seconds = Math.min(
+      Math.max(requestedSeconds, 1),
+      SpotifyApiService.maxRetryAfterSeconds
+    );
+
+    const retryAfterMs = seconds * 1000;
+    this._backoffUntil = now() + retryAfterMs;
+
+    return retryAfterMs;
   }
 }

--- a/src/utils/spotify/player/playlist.test.ts
+++ b/src/utils/spotify/player/playlist.test.ts
@@ -4,6 +4,8 @@ import { SpotifyService } from "@utils/spotify";
 import { SpotifyPlaylistService } from "@utils/spotify/player/playlist";
 import { testPlaylist } from "@/testData";
 import { getBiggestImageUrl } from "@utils/array";
+import ResponseError from "@/models/responseError";
+import { logger } from "@oceanity/firebot-helpers/firebot";
 
 describe("Spotify - Playlist Service", () => {
   let spotify: SpotifyService;
@@ -79,6 +81,114 @@ describe("Spotify - Playlist Service", () => {
       for (const [key, value] of Object.entries(defaults)) {
         expect(playlist[key as keyof SpotifyPlaylistService]).toBe(value);
       }
+    });
+  });
+
+  describe("playlists Spotify won't serve", () => {
+    // Spotify's own editorial and algorithmic playlists have 404'd since Nov 2024
+    const editorialUri = "spotify:playlist:37i9dQZF1DX5wDmLW735Yd";
+
+    const notFound = () =>
+      Promise.reject(
+        new ResponseError(
+          "Spotify API /playlists/37i9dQZF1DX5wDmLW735Yd returned status 404",
+          { status: 404 }
+        )
+      );
+
+    it("treats a 404 playlist as no playlist rather than throwing", async () => {
+      jest.spyOn(spotify.api, "fetch").mockImplementation(notFound);
+
+      await expect(
+        playlist.updateByUriAsync(editorialUri)
+      ).resolves.toBeUndefined();
+
+      for (const [key, value] of Object.entries(defaults)) {
+        expect(playlist[key as keyof SpotifyPlaylistService]).toBe(value);
+      }
+      expect(playlist.raw).toBe(null);
+    });
+
+    it("clears a previously populated playlist", async () => {
+      await playlist.updateByUriAsync(testPlaylist.uri);
+      expect(playlist.isActive).toBe(true);
+
+      jest.spyOn(spotify.api, "fetch").mockImplementation(notFound);
+      await playlist.updateByUriAsync(editorialUri);
+
+      expect(playlist.isActive).toBe(false);
+      expect(playlist.raw).toBe(null);
+    });
+
+    it("only asks Spotify once", async () => {
+      const fetchMock = jest
+        .spyOn(spotify.api, "fetch")
+        .mockImplementation(notFound);
+
+      await playlist.updateByUriAsync(editorialUri);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Re-entering the same playlist must not start the storm again
+      for (let i = 0; i < 5; i++) {
+        await playlist.updateByUriAsync(editorialUri);
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("still fetches other playlists", async () => {
+      const fetchMock = jest
+        .spyOn(spotify.api, "fetch")
+        .mockImplementation(notFound);
+
+      await playlist.updateByUriAsync(editorialUri);
+
+      fetchMock.mockReturnValue(
+        Promise.resolve({ ok: true, status: 200, data: testPlaylist })
+      );
+      await playlist.updateByUriAsync(testPlaylist.uri);
+
+      expect(playlist.isActive).toBe(true);
+      expect(playlist.name).toBe(testPlaylist.name);
+    });
+
+    it("propagates failures that aren't a 404", async () => {
+      jest
+        .spyOn(spotify.api, "fetch")
+        .mockImplementation(() =>
+          Promise.reject(
+            new ResponseError("Spotify API returned status 500", {
+              status: 500,
+            })
+          )
+        );
+
+      await expect(playlist.updateByUriAsync(editorialUri)).rejects.toThrow();
+    });
+  });
+
+  describe("init", () => {
+    it("handles a failing fetch instead of leaking an unhandled rejection", async () => {
+      await playlist.init();
+
+      jest
+        .spyOn(spotify.api, "fetch")
+        .mockImplementation(() => Promise.reject(new Error("boom")));
+
+      // EventEmitter does not await handlers, so the handler must catch its own
+      expect(() =>
+        spotify.player.state.emit(
+          "playlist-state-changed",
+          "spotify:playlist:abc"
+        )
+      ).not.toThrow();
+
+      // Let the handler's rejection settle
+      await new Promise(process.nextTick);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Error updating Spotify playlist"),
+        expect.any(Error)
+      );
     });
   });
 });

--- a/src/utils/spotify/player/playlist.ts
+++ b/src/utils/spotify/player/playlist.ts
@@ -4,12 +4,20 @@ import { logger } from "@oceanity/firebot-helpers/firebot";
 import { SpotifyService } from "@utils/spotify";
 import { getErrorMessage } from "@oceanity/firebot-helpers/string";
 import { trackSummaryFromDetails } from "./track";
+import ResponseError from "@/models/responseError";
 
 export class SpotifyPlaylistService {
   private readonly spotify: SpotifyService;
 
   private _playlist: SpotifyPlaylistDetails | null = null;
   private _summary: SpotifyPlaylistSummary | null = null;
+
+  /**
+   * Playlists Spotify refuses to serve us, so we stop asking. Since November
+   * 2024 the Web API 404s on Spotify's own editorial and algorithmic playlists,
+   * and that is never going to start working on a retry.
+   */
+  private readonly _unavailableUris = new Set<string>();
 
   public constructor(spotifyService: SpotifyService) {
     this.spotify = spotifyService;
@@ -18,7 +26,15 @@ export class SpotifyPlaylistService {
   public async init() {
     this.spotify.player.state.on(
       "playlist-state-changed",
-      async (uri?) => await this.updateByUriAsync(uri)
+      (uri?: string | null) => {
+        // Handle here, an EventEmitter won't await this for us
+        this.updateByUriAsync(uri).catch((error) => {
+          logger.error(
+            `Error updating Spotify playlist: ${getErrorMessage(error)}`,
+            error
+          );
+        });
+      }
     );
   }
 
@@ -72,7 +88,7 @@ export class SpotifyPlaylistService {
   }
 
   public async updateByUriAsync(playlistUri?: string | null): Promise<void> {
-    if (!playlistUri) {
+    if (!playlistUri || this._unavailableUris.has(playlistUri)) {
       this.update(null);
       return;
     }
@@ -92,11 +108,35 @@ export class SpotifyPlaylistService {
 
     const id = this.spotify.getIdFromUri(playlistUri);
 
-    const response = await this.spotify.api.fetch<SpotifyPlaylistDetails>(
-      `/playlists/${id}`
-    );
+    try {
+      const response = await this.spotify.api.fetch<SpotifyPlaylistDetails>(
+        `/playlists/${id}`
+      );
 
-    return response.data ?? null;
+      return response.data ?? null;
+    } catch (error) {
+      if (error instanceof ResponseError && error.data?.status === 404) {
+        this.markUnavailable(playlistUri);
+        return null;
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Records a playlist as one Spotify won't serve, so we only ever ask once.
+   */
+  private markUnavailable(playlistUri: string): void {
+    if (this._unavailableUris.has(playlistUri)) return;
+
+    this._unavailableUris.add(playlistUri);
+
+    logger.warn(
+      `Spotify returned 404 for playlist ${playlistUri}. Spotify no longer serves its own editorial and algorithmic playlists ` +
+        `(Discover Weekly, Daily Mix, Release Radar, Made For You, etc.) through the Web API, so playlist details will be ` +
+        `unavailable while this one is playing. No further requests will be made for it.`
+    );
   }
 
   private update(playlist: SpotifyPlaylistDetails | null): void {

--- a/src/utils/spotify/player/state.test.ts
+++ b/src/utils/spotify/player/state.test.ts
@@ -1,6 +1,9 @@
+import "@/mocks/firebot";
 import { jest } from "@jest/globals";
 import { SpotifyService } from "@utils/spotify";
 import { SpotifyStateService } from "./state";
+import { testTrack } from "@/testData";
+import ResponseError from "@/models/responseError";
 
 describe("Spotify - State Service", () => {
   let spotify: SpotifyService;
@@ -27,6 +30,169 @@ describe("Spotify - State Service", () => {
     it("should be ready on initialization", async () => {
       await state.init();
       expect(state.isReady).toBe(true);
+    });
+  });
+
+  describe("playlist context tracking", () => {
+    const playerStateWithContextUri = (uri: string | null) =>
+      ({
+        device: { volume_percent: 50 },
+        is_playing: true,
+        progress_ms: 0,
+        item: testTrack,
+        context: uri
+          ? {
+              external_urls: { spotify: "https://open.spotify.com/playlist/x" },
+              href: "https://api.spotify.com/v1/playlists/x",
+              type: "playlist",
+              uri,
+            }
+          : null,
+      } as unknown as SpotifyPlayer);
+
+    let playlistStateChanged: jest.Mock;
+
+    /**
+     * Runs the real update once per call. `tick` is stubbed out because it
+     * otherwise reschedules itself forever.
+     */
+    const poll = async (times: number) => {
+      for (let i = 0; i < times; i++) {
+        await state.updatePlaybackStateAsync();
+      }
+    };
+
+    beforeEach(() => {
+      // Use the real implementation, the outer beforeEach stubs it out
+      jest.spyOn(state, "updatePlaybackStateAsync").mockRestore();
+      jest
+        .spyOn(state as any, "tick")
+        .mockImplementation(() => Promise.resolve());
+      jest.spyOn(spotify.auth, "isLinked", "get").mockReturnValue(true);
+
+      playlistStateChanged = jest.fn();
+      state.on("playlist-state-changed", playlistStateChanged);
+    });
+
+    it("emits once for an unchanged playlist, however many times we poll", async () => {
+      jest.spyOn(spotify.api, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: playerStateWithContextUri("spotify:playlist:abc"),
+      } as any);
+
+      await poll(10);
+
+      // Regression: this used to re-emit every poll whenever the playlist
+      // fetch failed, hammering Spotify at 1Hz until it rate limited us
+      expect(playlistStateChanged).toHaveBeenCalledTimes(1);
+      expect(playlistStateChanged).toHaveBeenCalledWith("spotify:playlist:abc");
+    });
+
+    it("emits again when the playlist actually changes", async () => {
+      const fetchMock = jest.spyOn(spotify.api, "fetch");
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: playerStateWithContextUri("spotify:playlist:abc"),
+      } as any);
+      await poll(3);
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: playerStateWithContextUri("spotify:playlist:xyz"),
+      } as any);
+      await poll(3);
+
+      expect(playlistStateChanged).toHaveBeenCalledTimes(2);
+      expect(playlistStateChanged).toHaveBeenLastCalledWith(
+        "spotify:playlist:xyz"
+      );
+    });
+
+    it("emits null once when playback leaves a playlist", async () => {
+      const fetchMock = jest.spyOn(spotify.api, "fetch");
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: playerStateWithContextUri("spotify:playlist:abc"),
+      } as any);
+      await poll(2);
+
+      // Playing from an album or search results carries no playlist context
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: playerStateWithContextUri(null),
+      } as any);
+      await poll(5);
+
+      expect(playlistStateChanged).toHaveBeenCalledTimes(2);
+      expect(playlistStateChanged).toHaveBeenLastCalledWith(null);
+    });
+
+    it("stays quiet when there is no playlist context at all", async () => {
+      jest.spyOn(spotify.api, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: playerStateWithContextUri(null),
+      } as any);
+
+      await poll(5);
+
+      expect(playlistStateChanged).not.toHaveBeenCalled();
+    });
+
+    describe("wired to the playlist service", () => {
+      // Spotify has 404'd its own editorial playlists since Nov 2024
+      const editorialUri = "spotify:playlist:37i9dQZF1DX5wDmLW735Yd";
+
+      it("asks for an unavailable playlist once, not once per poll", async () => {
+        const fetchMock = jest
+          .spyOn(spotify.api, "fetch")
+          .mockImplementation((endpoint: string) => {
+            if (endpoint.startsWith("/playlists/")) {
+              return Promise.reject(
+                new ResponseError(
+                  `Spotify API ${endpoint} returned status 404`,
+                  { status: 404 }
+                )
+              );
+            }
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              data: playerStateWithContextUri(editorialUri),
+            }) as any;
+          });
+
+        // The playlist service listens to the player's own state service, so
+        // drive that one rather than the standalone instance above
+        const wiredState = spotify.player.state;
+        jest
+          .spyOn(wiredState as any, "tick")
+          .mockImplementation(() => Promise.resolve());
+
+        await spotify.player.playlist.init();
+
+        for (let i = 0; i < 30; i++) {
+          await wiredState.updatePlaybackStateAsync();
+        }
+        // Let the playlist handler's promises settle
+        await new Promise(process.nextTick);
+
+        const playlistCalls = fetchMock.mock.calls.filter(([endpoint]) =>
+          String(endpoint).startsWith("/playlists/")
+        );
+
+        // This is the reported bug: 30 polls used to mean 30 requests, which
+        // ran at 1Hz for 85 minutes and got the integration rate limited
+        expect(playlistCalls).toHaveLength(1);
+        expect(spotify.player.playlist.isActive).toBe(false);
+      });
     });
   });
 });

--- a/src/utils/spotify/player/state.ts
+++ b/src/utils/spotify/player/state.ts
@@ -2,12 +2,20 @@ import { logger } from "@oceanity/firebot-helpers/firebot";
 import { delay, now } from "@utils/time";
 import { SpotifyService } from "@utils/spotify";
 import { EventEmitter } from "events";
+import RateLimitedError from "@/models/rateLimitedError";
 
 export class SpotifyStateService extends EventEmitter {
   private readonly spotify: SpotifyService;
 
   private _progressMs: number = 0;
   private _isReady: boolean = false;
+
+  /**
+   * Uri of the playlist context Spotify last reported, tracked here rather than
+   * read back off the playlist service so a failed playlist fetch doesn't
+   * re-trigger itself on every poll.
+   */
+  private _contextUri: string | null = null;
 
   constructor(spotifyService: SpotifyService) {
     super();
@@ -30,7 +38,7 @@ export class SpotifyStateService extends EventEmitter {
 
     try {
       if (!this.spotify.auth.isLinked) {
-        this.emit("state-cleared", undefined);
+        this.clearState();
         await delay(15000, startTime);
         return this.updatePlaybackStateAsync();
       }
@@ -40,7 +48,7 @@ export class SpotifyStateService extends EventEmitter {
         null;
 
       if (!state) {
-        this.emit("state-cleared", undefined);
+        this.clearState();
         await delay(5000, startTime);
         return this.updatePlaybackStateAsync();
       }
@@ -49,16 +57,13 @@ export class SpotifyStateService extends EventEmitter {
         this.emit("is-playing-state-changed", state.is_playing);
       }
 
-      if (state.context) {
-        switch (state.context.type) {
-          case "playlist":
-            if (state.context.uri !== this.spotify.player.playlist.uri) {
-              this.emit("playlist-state-changed", state.context.uri);
-            }
-            break;
-        }
-      } else {
-        this.emit("playlist-state-changed", null);
+      const contextUri =
+        state.context?.type === "playlist" ? state.context.uri : null;
+
+      // Edge triggered, otherwise a playlist we can't fetch is retried every poll
+      if (contextUri !== this._contextUri) {
+        this._contextUri = contextUri;
+        this.emit("playlist-state-changed", contextUri);
       }
 
       // If target volume, user has manually changed volume and we don't want it falling back
@@ -79,9 +84,19 @@ export class SpotifyStateService extends EventEmitter {
       }
       return this.tick(state.is_playing ? 1000 : 5000, startTime);
     } catch (error) {
+      // Already reported once per window by the api service, just stand down
+      if (error instanceof RateLimitedError) {
+        return this.tick(Math.max(error.retryAfterMs, 1000), startTime);
+      }
+
       logger.error("Error checking track change on Spotify", error);
       return this.tick(15000, startTime);
     }
+  }
+
+  private clearState(): void {
+    this._contextUri = null;
+    this.emit("state-cleared", undefined);
   }
 
   private async tick(delayMs: number, startTime: number): Promise<void> {


### PR DESCRIPTION
Fixes #107.

Playing a Spotify-owned editorial or algorithmic playlist put the integration into a 1Hz retry loop that ran until Spotify rate limited the whole app — 34,993 404s in 85 minutes, then 7,333 more local throws over the following two hours, for a 36MB log. Full analysis in #107.

### The core fix

`SpotifyStateService` decided whether to refetch the playlist by comparing the live context uri against the **last successfully fetched** playlist, so a failed fetch re-armed its own trigger on the very next poll:

```ts
if (state.context.uri !== this.spotify.player.playlist.uri) {   // "" when the fetch failed
```

The state service now tracks the context uri itself, making the fetch edge triggered:

```ts
const contextUri = state.context?.type === "playlist" ? state.context.uri : null;

if (contextUri !== this._contextUri) {
  this._contextUri = contextUri;
  this.emit("playlist-state-changed", contextUri);
}
```

That also removes a `playlist-state-changed(null)` that re-emitted every tick whenever playback had no context.

### The rest

**`playlist.ts`** — remembers uris Spotify 404s and stops asking, warning once with an explanation of the November 2024 API change. Such a playlist reads as inactive rather than retrying forever. The `playlist-state-changed` handler now catches its own rejections; it was an `async` function on an `EventEmitter`, which nothing awaits, so every throw became an `Unhandled promise rejection`.

**`api.ts`** — the rate limit gate was keyed per endpoint, but Spotify rate limits per app, so a 429 anywhere now quiets everything. A missing `Retry-After` defaults to 30s rather than 3600s, and the value is capped at 5 minutes so an unusually long one cannot take the integration offline for an extended stretch. Being gated throws a typed `RateLimitedError` carrying `retryAfterMs`, reported once per window at `warn` instead of once per call at `error`.

**`state.ts`** — stands down for the real retry window when rate limited, instead of retrying every 15s.

This also replaces `new Date(performance.now() + ...).toUTCString()` in the rate limit message, which rendered as `Fri, 02 Jan 1970 00:04:24 GMT`. That is the second broken timestamp mentioned in #106; the token expiry one is handled separately in #112.

### Behaviour change worth flagging

A playlist Spotify will not serve now reports as **no playlist**: `spotifyIsPlaylistActive` is `false` and the `spotifyPlaylist[...]` variables are empty, the same as playing from an album or search. The alternative was a partial summary synthesised from the playback context (id and url populated, name and tracks empty); I went with the cleaner state rather than half-filled variables, but say the word if you would rather have the partial data.

### Tests

18 new tests, 114 passing total. They are genuine regression guards, not just coverage — against the unfixed source:

- the four `state.test.ts` context-tracking tests fail
- the end-to-end test (`state` wired to `playlist`, 30 polls against a 404ing playlist) **crashes the process on an unhandled rejection** before its assertion is even reached, reproducing the exact failure mode from the logs

Also covered: the backoff is global rather than per endpoint, a missing `Retry-After` yields 30s and not an hour, a long `Retry-After` is capped, gated calls never reach the network, and rate limiting warns once per window rather than once per call.

### Verification

`npm test` (114 passing), `npx tsc --noEmit` clean, `npm run build` succeeds.

Confirmed live on Firebot v5.66.7. Before: ~140 log lines/minute, sustained. After, across three sessions with the same Daily Mix playing: exactly one 404 and one explanatory warning per session, zero 429s, zero rate limiting. Playback, track and volume variables unaffected; `request-song` effects continued to work normally.
