### PR TITLE
Fix token expiry logs rendering as 1970 timestamps

### DIFF
--- a/src/spotifyIntegration.ts
+++ b/src/spotifyIntegration.ts
@@ -9,6 +9,7 @@ import {
   logger,
   variableManager,
 } from "@oceanity/firebot-helpers/firebot";
+import { formatMsToTimecode } from "@oceanity/firebot-helpers/string";
 import { now } from "@utils/time";
 import { EventEmitter } from "events";
 import { AllSpotifyEffects } from "./firebot/effects";
@@ -128,8 +129,9 @@ export class SpotifyIntegration extends EventEmitter {
         data.refresh_token = auth.refresh_token;
 
         this.expiresAt = now() + data.expires_in * 1000;
+        // expiresAt is monotonic (performance.now based), not a wall clock epoch
         logger.info(
-          `New token expires at ${new Date(this.expiresAt).toUTCString()}`
+          `New token expires in ${formatMsToTimecode(this.expiresAt - now())}`
         );
 
         updateIntegrationAuth(data);

--- a/src/utils/spotify/auth.ts
+++ b/src/utils/spotify/auth.ts
@@ -1,7 +1,10 @@
 import { integrationManager, logger } from "@oceanity/firebot-helpers/firebot";
 import { integration } from "@/spotifyIntegration";
 import { SpotifyService } from "@utils/spotify";
-import { getErrorMessage } from "@oceanity/firebot-helpers/string";
+import {
+  formatMsToTimecode,
+  getErrorMessage,
+} from "@oceanity/firebot-helpers/string";
 import { now } from "@utils/time";
 import { namespace } from "@/main";
 
@@ -58,10 +61,11 @@ export default class SpotifyAuthService {
 
       this.expiresAt = now() + refreshResponse.expires_in * 1000;
 
+      // expiresAt is monotonic (performance.now based), not a wall clock epoch
       logger.info(
-        `Refreshed Spotify Token. New Token will expire at ${new Date(
-          this.expiresAt
-        ).toUTCString()}`
+        `Refreshed Spotify Token. New Token will expire in ${formatMsToTimecode(
+          this.expiresAt - now()
+        )}`
       );
 
       return refreshResponse.access_token;


### PR DESCRIPTION
Refs #106.

`expiresAt` is derived from `now()`, which is `performance.now()` — a monotonic offset from process start, not a Unix epoch. Passing it to `new Date(...).toUTCString()` produced the lines reported in #106:

```
New token expires at Thu, 01 Jan 1970 03:47:55 GMT
```

This logs the remaining lifetime instead, in `src/utils/spotify/auth.ts` and `src/spotifyIntegration.ts`.

### On the underlying suggestion in #106

#106 suggests switching `expiresAt` to `Date.now()`. I looked at that and went with the narrower change, because both call sites compare `expiresAt` as a delta within a single process:

```ts
// src/utils/spotify/auth.ts:84
if (this.expiresAt && this.expiresAt - now() > 5000) return false;

// src/spotifyIntegration.ts:87
this.expiresAt && this.expiresAt - now() > 5000
```

`performance.now()` is internally consistent for that comparison, so the expiry check itself is correct today and only the rendering was wrong. Switching to `Date.now()` would also work, but it would mix clock sources with the monotonic `now()` used for the poll loop's delays and the rate limit backoff, which seemed like the worse trade.

One detail from #106 I could not reproduce: the report says every restart forces a full token refresh. On restart `expiresAt` is `0`/`null`, so the guard above is falsy and it falls through to `spotifyIsConnectedAsync()` — an extra `GET /v1/me` validation call rather than a refresh. If the token is still valid it is reused. So there is an extra request per restart, but not a refresh.

Happy to redo this as a `Date.now()` change if you would prefer that; it is a small diff either way.

The other broken timestamp #106 mentions, the rate limit "will be able to use again after", is fixed separately in #111 as part of reworking that gate.

### Verification

`npx tsc --noEmit` clean, `npm test` passing (114).

Not yet observed live — no token refresh has happened since installing the build, so this is verified by inspection and the type checker rather than by a log line. The rendering change is small enough that I did not add a test for it; happy to if you would like one.
