### PR TITLE
Fix build:dev failing to locate the Firebot folder on Linux and macOS

### DIFF
--- a/scripts/copy-build.ts
+++ b/scripts/copy-build.ts
@@ -21,9 +21,10 @@ const getFirebotScriptsFolderPath = () => {
   if (process.platform === "win32") {
     appDataFolderPath = process.env.APPDATA;
   } else if (process.platform === "darwin") {
-    appDataFolderPath = path.resolve(home, "/Library/Application Support");
+    // Leading slashes would make path.resolve discard the home directory
+    appDataFolderPath = path.resolve(home, "Library/Application Support");
   } else if (process.platform === "linux") {
-    appDataFolderPath = path.resolve(home, "/.config");
+    appDataFolderPath = path.resolve(home, ".config");
   }
 
   if (!appDataFolderPath) {


### PR DESCRIPTION
Fixes #108.

`npm run build:dev` built fine but never installed the script, failing in the copy step with a path that had lost the home directory:

```
Error: Cannot find module '/.config/Firebot/v5/global-settings.json'
```

`path.resolve` processes segments right to left and stops at the first absolute one, discarding everything before it. Both non-Windows branches passed a leading slash, so `home` was thrown away:

```js
path.resolve("/home/user", "/.config")                      // => "/.config"
path.resolve("/Users/user", "/Library/Application Support")  // => "/Library/Application Support"
```

Dropping the leading slashes lets the segments join onto the home directory as intended. Only `win32` was unaffected, since it reads `APPDATA` directly.

### Verification

On Linux, `npm run build:dev` now resolves the active profile and copies the built script into the Firebot scripts folder:

```
webpack 5.89.0 compiled successfully in 934 ms
Successfully copied oceanitySpotifyIntegration.js to Firebot scripts folder.
```

The darwin branch is the same defect and the same one-line change, but I have no macOS machine to confirm it on — that line is reasoned from `path.resolve` semantics rather than tested.
